### PR TITLE
Register missing broadcasts when importing a sprite

### DIFF
--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -721,7 +721,7 @@ class Target extends EventEmitter {
             return null;
         };
 
-        const allReferences = this.blocks.getAllVariableAndListReferences();
+        const allReferences = this.blocks.getAllVariableAndListReferences(null, true);
         const unreferencedLocalVarIds = [];
         if (Object.keys(this.variables).length > 0) {
             for (const localVarId in this.variables) {

--- a/test/unit/engine_target.js
+++ b/test/unit/engine_target.js
@@ -811,3 +811,59 @@ test('fixUpVariableReferences does not change variable name if there is no varia
 
     t.end();
 });
+
+test('fixUpVariableReferences creates missing broadcasts on the stage', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    stage.createVariable('existing broadcast id', 'message1', Variable.BROADCAST_MESSAGE_TYPE);
+
+    target.blocks.createBlock({
+        id: 'a broadcast menu block',
+        opcode: 'event_broadcast_menu',
+        fields: {
+            BROADCAST_OPTION: {
+                name: 'BROADCAST_OPTION',
+                id: 'imported broadcast id 1',
+                value: 'message1',
+                variableType: Variable.BROADCAST_MESSAGE_TYPE
+            }
+        },
+        inputs: {},
+        topLevel: true
+    });
+    target.blocks.createBlock({
+        id: 'a broadcast hat block',
+        opcode: 'event_whenbroadcastreceived',
+        fields: {
+            BROADCAST_OPTION: {
+                name: 'BROADCAST_OPTION',
+                id: 'imported broadcast id 2',
+                value: 'message2',
+                variableType: Variable.BROADCAST_MESSAGE_TYPE
+            }
+        },
+        inputs: {},
+        topLevel: true
+    });
+
+    target.fixUpVariableReferences();
+
+    t.equal(target.blocks.getBlock('a broadcast menu block').fields.BROADCAST_OPTION.id,
+        'existing broadcast id');
+    const newBroadcast = stage.variables['imported broadcast id 2'];
+    t.type(newBroadcast, 'object');
+    t.equal(newBroadcast.type, Variable.BROADCAST_MESSAGE_TYPE);
+    t.equal(newBroadcast.name, 'message2');
+    t.equal(Object.keys(target.variables).length, 0);
+
+    t.end();
+});


### PR DESCRIPTION
Fixes #3.

When a sprite is imported (`vm.addSprite`), `installTargets` calls `fixUpVariableReferences()` to merge or create any global variables the sprite's blocks reference, but it fetched references without the `optIncludeBroadcast` flag, so `BROADCAST_OPTION` fields were skipped and the broadcast variable was never created on the stage. Broadcast blocks bail silently when `lookupBroadcastMsg` finds nothing. In the editor, scratch-blocks masks this by creating the variable during workspace load, which is why "see inside" made the project work.

The fix passes the broadcast flag so broadcast references flow through the same machinery as variables and lists: a broadcast whose name already exists on the stage gets its block fields re-pointed to the existing variable's id, and a new broadcast is created on the stage under the imported id. The `_broadcastCleanupNeeded` sweep only deletes broadcasts no block references, so the new ones survive.

Compared to the PenguinMod fix linked in the issue, this also handles the `event_whenbroadcastreceived` hat field, merges with existing same-named broadcasts instead of creating duplicates, and covers sprite2 imports.

Added a unit test covering both paths (merge with existing broadcast, create missing one); `test/unit/engine_target.js` passes 35/35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MistWarp/codesmith/scratch-vm/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786645098&installation_id=145714314&pr_number=7&repository=MistWarp%2Fscratch-vm&return_to=https%3A%2F%2Fgithub.com%2FMistWarp%2Fscratch-vm%2Fpull%2F7&signature=111fc78998daa28019e311160a26b17cd45148e32f213270208ebba07e0c875f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->